### PR TITLE
Changed price parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ export function initClientScript(clientKey:string, cookieDomain:string, apiEndpo
  * @param qty - The number of unit added. Total price of the product is calculated by unit price multiplied by quantity. Required
  * @param price - The unit price of the product. Total price of the product is calculated by unit price multiplied by quantity. 
  */
-export function sendAddEvent(page:string,productType:string, itemId: string, productName:string, productId:string, orderDate:string, qty:number, price: string) {
+export function sendAddEvent(page:string,productType:string, itemId: string, productName:string, productId:string, orderDate:string, qty:number, price:number) {
     if(!window._boxever) return
     window._boxeverq.push(function() {
         let addEvent =  baseEvent(page, EventType.Add) 


### PR DESCRIPTION
I believe the price parameter of the sendAddEvent function has a wrong type of string and it should be number.
Even though the event works for the most part, it I think the abandoned cart part doesn't work and it blocks the 'Abandoned Revenue' value on the session from being updated.
According to the documentation the product.price property is also of type number: https://doc.sitecore.com/cdp/en/developers/sitecore-customer-data-platform--data-model-2-1/send-an-add-event-to-sitecore-cdp.html